### PR TITLE
Terragrunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,19 @@ To deploy Dirigible with Postgres as database using docker-compose, follow these
 - Modify the dirigible/tomcat_users.xml to configure users and passwords.
 - Run docker-compose up
 - Access https://localhost:8080
+
+# To deploy the Eclipse Dirigible in Google Kubernetes Engine
+
+- Clone this repo:
+- git clone https://github.com/dcna-io/dirigible-docker.git
+- Export an env variable with the path to your GCP credentials:
+- export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/credentials.json
+- Export an env variable with GCP project ID:
+- export PROJECT_ID="$(gcloud config get-value project -q)"
+- Build the docker image:
+- docker build -t gcr.io/${PROJECT_ID}/dirigible ./dirigible
+- Push the created image to GCP registry:
+- docker push gcr.io/${PROJECT_ID}/dirigible
+- Go to cloud/dev/ and edit the variables in all .tfvars files
+- Execute terragrunt apply-all
+- Access the Dirigible app using the IP address shown  at the end of execution

--- a/cloud/dev/.gitignore
+++ b/cloud/dev/.gitignore
@@ -1,0 +1,2 @@
+terraform.tfvars
+global.tfvars

--- a/cloud/dev/app/.gitignore
+++ b/cloud/dev/app/.gitignore
@@ -1,0 +1,2 @@
+terraform.tfvars
+.terragrunt*

--- a/cloud/dev/app/terraform.tfvars.example
+++ b/cloud/dev/app/terraform.tfvars.example
@@ -1,0 +1,11 @@
+terragrunt = {
+  dependencies {
+    paths = ["../gke", "../postgresql"]
+  }
+  terraform {
+    source = "git::https://github.com/dcna-io/dirigible-gke//app"
+  }
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}

--- a/cloud/dev/gke/.gitignore
+++ b/cloud/dev/gke/.gitignore
@@ -1,0 +1,2 @@
+terraform.tfvars
+.terragrunt*

--- a/cloud/dev/gke/terraform.tfvars.example
+++ b/cloud/dev/gke/terraform.tfvars.example
@@ -1,0 +1,14 @@
+terragrunt = {
+  terraform {
+    source = "git::https://github.com/dcna-io/dirigible-gke//gke"
+  }
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+project_id = ""
+region = ""
+zone = ""
+cluster_name = ""
+initial_node_count = 2

--- a/cloud/dev/global.tfvars.example
+++ b/cloud/dev/global.tfvars.example
@@ -1,0 +1,10 @@
+username = ""
+password = ""
+DB       = ""
+DB_PASSWORD = ""
+DB_USER = ""
+
+bucket  = ""
+prefix    = ""
+project = ""
+

--- a/cloud/dev/postgresql/.gitignore
+++ b/cloud/dev/postgresql/.gitignore
@@ -1,0 +1,2 @@
+terraform.tfvars
+.terragrunt*

--- a/cloud/dev/postgresql/terraform.tfvars.example
+++ b/cloud/dev/postgresql/terraform.tfvars.example
@@ -1,0 +1,13 @@
+terragrunt = {
+    dependencies {
+    paths = ["../gke"]
+  }
+  terraform {
+    source = "git::https://github.com/dcna-io/dirigible-gke//postgresql"
+  }
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+postgres_storage = "1Gi"

--- a/cloud/dev/terraform.tfvars.example
+++ b/cloud/dev/terraform.tfvars.example
@@ -1,0 +1,23 @@
+terragrunt = {
+  # Configure Terragrunt to automatically store tfstate files in an S3 bucket
+  # Configure root level variables that all resources can inherit
+  remote_state {
+
+  backend = "gcs"
+    config {
+      bucket  = "bucket_name"
+      prefix    = "${path_relative_to_include()}/terraform.tfstate"
+      project = "project_name"
+    }
+  }
+
+  terraform {
+    extra_arguments "-var-file" {
+      commands = ["${get_terraform_commands_that_need_vars()}"]
+
+      optional_var_files = [
+        "${get_tfvars_dir()}/${find_in_parent_folders("global.tfvars", "ignore")}",
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Create Terragrunt configurations to use https://github.com/dcna-io/dirigible-gke modules to deploy Dirigible in Google Kubernetes Engine.